### PR TITLE
add/#14 코어데이터 CoredataManager 구현

### DIFF
--- a/Sgrr/Sgrr.xcodeproj/project.pbxproj
+++ b/Sgrr/Sgrr.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		43D756202C57760500D52E06 /* CoredataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D7561F2C57760500D52E06 /* CoredataManager.swift */; };
 		86034B962C51DAA4006106BC /* SgrrApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86034B952C51DAA4006106BC /* SgrrApp.swift */; };
 		86034B982C51DAA4006106BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86034B972C51DAA4006106BC /* ContentView.swift */; };
 		86034B9A2C51DAA5006106BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 86034B992C51DAA5006106BC /* Assets.xcassets */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		43D7561F2C57760500D52E06 /* CoredataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoredataManager.swift; sourceTree = "<group>"; };
 		86034B922C51DAA4006106BC /* Sgrr.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sgrr.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		86034B952C51DAA4006106BC /* SgrrApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SgrrApp.swift; sourceTree = "<group>"; };
 		86034B972C51DAA4006106BC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -54,6 +56,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		43D7561E2C57730400D52E06 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				43D7561F2C57760500D52E06 /* CoredataManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		86034B892C51DAA4006106BC = {
 			isa = PBXGroup;
 			children = (
@@ -73,6 +83,7 @@
 		86034B942C51DAA4006106BC /* Sgrr */ = {
 			isa = PBXGroup;
 			children = (
+				43D7561E2C57730400D52E06 /* Manager */,
 				43D7561D2C57355000D52E06 /* Model */,
 				86034B952C51DAA4006106BC /* SgrrApp.swift */,
 				86034B972C51DAA4006106BC /* ContentView.swift */,
@@ -174,6 +185,7 @@
 				86034BAA2C5234CB006106BC /* Cake3DView.swift in Sources */,
 				86034B962C51DAA4006106BC /* SgrrApp.swift in Sources */,
 				86034BA22C51DAA5006106BC /* Sgrr.xcdatamodeld in Sources */,
+				43D756202C57760500D52E06 /* CoredataManager.swift in Sources */,
 				860C87EE2C53922400D9FC24 /* CakeCanvasView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sgrr/Sgrr.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Sgrr/Sgrr.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "09429E4D-B347-41F0-A247-4CCDEDA8280C"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/Sgrr/Sgrr/ContentView.swift
+++ b/Sgrr/Sgrr/ContentView.swift
@@ -10,23 +10,24 @@ import CoreData
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
-
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
-        animation: .default)
-    private var items: FetchedResults<Item>
+    
+    // MARK: - 코어데이터 Read 패치하는 코드
+    @FetchRequest(entity: OrderForm.entity(),
+                  sortDescriptors: [NSSortDescriptor(keyPath: \OrderForm.elementKeyword, ascending: true)]
+    )
+    var orderForm: FetchedResults<OrderForm>
 
     var body: some View {
         NavigationView {
             List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
-                    } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
-                    }
-                }
-                .onDelete(perform: deleteItems)
+//                ForEach(items) { item in
+//                    NavigationLink {
+//                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+//                    } label: {
+//                        Text(item.timestamp!, formatter: itemFormatter)
+//                    }
+//                }
+//                .onDelete(perform: deleteItems)
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -44,8 +45,8 @@ struct ContentView: View {
 
     private func addItem() {
         withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+//            let newItem = Item(context: viewContext)
+//            newItem.timestamp = Date()
 
             do {
                 try viewContext.save()
@@ -60,7 +61,7 @@ struct ContentView: View {
 
     private func deleteItems(offsets: IndexSet) {
         withAnimation {
-            offsets.map { items[$0] }.forEach(viewContext.delete)
+//            offsets.map { items[$0] }.forEach(viewContext.delete)
 
             do {
                 try viewContext.save()

--- a/Sgrr/Sgrr/Manager/CoredataManager.swift
+++ b/Sgrr/Sgrr/Manager/CoredataManager.swift
@@ -34,7 +34,7 @@ class CoredataManager {
 
 extension CoredataManager {
     // MARK: - 저장, 업데이트
-    func saveOrUpdateOrder(colorBG: String, colorLetter: String, conceptKey: String, conceptImg: String, elementKey: [String], elementImg: [String]) {
+    func saveOrUpdateOrder(colorBG: String, colorLetter: String, conceptKey: String, conceptImg: Data, elementKey: [String], elementImg: [Data]) {
         let fetchRequest: NSFetchRequest<OrderForm> = OrderForm.fetchRequest()
         
         do {

--- a/Sgrr/Sgrr/Manager/CoredataManager.swift
+++ b/Sgrr/Sgrr/Manager/CoredataManager.swift
@@ -1,0 +1,77 @@
+//
+//  CoredataManager.swift
+//  Sgrr
+//
+//  Created by Lee Wonsun on 7/29/24.
+//
+
+import Foundation
+import CoreData
+
+class CoredataManager {
+    static var shared: CoredataManager = CoredataManager()
+    private init () {}
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Sgrr")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        
+        return container
+    } ()
+    
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+}
+
+extension CoredataManager {
+    // MARK: - 저장, 업데이트
+    func saveOrUpdateOrder(colorBG: String, colorLetter: String, conceptKey: String, conceptImg: String, elementKey: [String], elementImg: [String]) {
+        let fetchRequest: NSFetchRequest<OrderForm> = OrderForm.fetchRequest()
+        
+        do {
+            let orderResult = try context.fetch(fetchRequest)
+            let orderForm: OrderForm
+            
+            if let existingOrder = orderResult.first {
+                orderForm = existingOrder
+            } else {
+                orderForm = OrderForm(context: context)
+                orderForm.uuid = UUID()
+            }
+            
+            orderForm.colorBackground = colorBG
+            orderForm.colorLettering = colorLetter
+            orderForm.conceptKeyword = conceptKey
+            orderForm.conceptImage = conceptImg
+            orderForm.elementKeyword = elementKey
+            orderForm.elementImage = elementImg
+            
+            try context.save()
+            
+        } catch {
+            print("오류 타입: \(error.localizedDescription)")
+            fatalError("Failed to save context, \(error.localizedDescription)")
+        }
+    }
+    
+    
+    // MARK: - 삭제
+    func deleteOrder(orderForm: OrderForm) {
+        do {
+            context.delete(orderForm)
+            try context.save()
+        } catch {
+            print("오류 타입: \(error.localizedDescription)")
+            fatalError("Failed to delete context, \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sgrr/Sgrr/Model/Sgrr.xcdatamodeld/Sgrr.xcdatamodel/contents
+++ b/Sgrr/Sgrr/Model/Sgrr.xcdatamodeld/Sgrr.xcdatamodel/contents
@@ -3,9 +3,9 @@
     <entity name="OrderForm" representedClassName="OrderForm" syncable="YES" codeGenerationType="class">
         <attribute name="colorBackground" optional="YES" attributeType="String"/>
         <attribute name="colorLettering" optional="YES" attributeType="String"/>
-        <attribute name="conceptImage" optional="YES" attributeType="String"/>
+        <attribute name="conceptImage" optional="YES" attributeType="Binary"/>
         <attribute name="conceptKeyword" optional="YES" attributeType="String"/>
-        <attribute name="elementImage" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="elementImage" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Data]"/>
         <attribute name="elementKeyword" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>

--- a/Sgrr/Sgrr/Persistence.swift
+++ b/Sgrr/Sgrr/Persistence.swift
@@ -14,8 +14,8 @@ struct PersistenceController {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
         for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+//            let newItem = Item(context: viewContext)
+//            newItem.timestamp = Date()
         }
         do {
             try viewContext.save()

--- a/Sgrr/Sgrr/SgrrApp.swift
+++ b/Sgrr/Sgrr/SgrrApp.swift
@@ -13,8 +13,8 @@ struct SgrrApp: App {
 
     var body: some Scene {
         WindowGroup {
-//            ContentView()
-//                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+            ContentView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
             //Cake3DView()
             Canvas()
             //NuggiedItemCell()


### PR DESCRIPTION
## 📝 작업 내용

> CoredataManager (CRUD) 구현
- 저장, 업데이트 : Cakey에서는 저장버튼과 추후 업데이트하고 저장 버튼이 동일함 (= 같은 save 함수 내에서 처리)
- 삭제 : delete 함수 구현
- 불러오기(read) : CoredataManager 내에서가 아닌 해당 뷰에서 fetchRequest로 불러오게끔 설정

## 📷 스크린샷 (선택)

1. 저장 / 업데이트 / 삭제 구현

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/411d12ec-7f6d-4213-bade-dd96d24083ae">


2. 불러오기(read) 구현

<img width="753" alt="image" src="https://github.com/user-attachments/assets/428878ae-ddfc-40f7-b48a-3ced72db16bb">


## 💬 리뷰 요구사항(선택)

> 혹시 다른 의견이 있다면 언제든 말씀부탁드림다람지🐿️
> 그리고... 혹시나 더 알아보고 변경될 수도 있습니다람지! 변경되면 공유하겠습니다

## 💡 관련 이슈
- Resolved: #14 
